### PR TITLE
Adding binary-only Carthage support

### DIFF
--- a/Carthage.json
+++ b/Carthage.json
@@ -1,0 +1,14 @@
+{
+  "4.6.4": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.6.4/AppsFlyerTracker.framework.zip",
+  "4.6.5": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.6.5/AppsFlyerTracker.framework.zip",
+  "4.7.0": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.0/AppsFlyerTracker.framework.zip",
+  "4.7.2": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.2/AppsFlyerTracker.framework.zip",
+  "4.7.3": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.3/AppsFlyerTracker.framework.zip",
+  "4.7.6": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.6/AppsFlyerTracker.framework.zip",
+  "4.7.7": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.7/AppsFlyerTracker.framework.zip",
+  "4.7.8": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.8/AppsFlyerTracker.framework.zip",
+  "4.7.9": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.9/AppsFlyerTracker.framework.zip",
+  "4.7.11": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.11/AppsFlyerTracker.framework.zip",
+  "4.8.0": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.8.0/AppsFlyerTracker.framework.zip",
+  "4.8.1": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.8.1/AppsFlyerTracker.framework.zip"
+}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import AppsFlyerLib
 
 Just add the following into your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile):
 ```
-binary "https://raw.githubusercontent.com/RxSwiftCommunity/RxKeyboard/master/Carthage.json"
+binary "https://raw.githubusercontent.com/AppsFlyerSDK/AppsFlyerFramework/master/Carthage.json"
 ```
 
 Then run

--- a/README.md
+++ b/README.md
@@ -17,12 +17,36 @@ Installation
 
 Just add `pod 'AppsFlyerFramework'` into your [Podfile](https://guides.cocoapods.org/syntax/podfile.html).
 
-Then run `pod install`.
+Then run
 
-Finally add `import AppsFlyerLib` in your Swift implementation.
+```zsh
+$ pod install
+```
 
-Or `#import <AppsFlyerTracker/AppsFlyerTracker.h>` if you're using Objective-C.<br>
-For version 4.5.12 `#import <AppsFlyerLib/AppsFlyerTracker.h>`
+Finally, import the framework:
+
+```swift
+// Swift
+import AppsFlyerLib
+```
+
+```objc
+// ObjC
+#import <AppsFlyerTracker/AppsFlyerTracker.h>
+```
+
+### Carthage
+
+Just add the following into your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile):
+```
+binary "https://raw.githubusercontent.com/RxSwiftCommunity/RxKeyboard/master/Carthage.json"
+```
+
+Then run
+
+```zsh
+$ carthage bootstrap
+```
 
 Changelog
 ------------


### PR DESCRIPTION
As discussed in the Carthage documentation:
https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-only-frameworks
and
https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-project-specification