### PR TITLE
Fix Carthage binary file reference naming

### DIFF
--- a/AppsFlyerTracker.json
+++ b/AppsFlyerTracker.json
@@ -1,0 +1,16 @@
+{
+  "4.6.4": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.6.4/AppsFlyerTracker.framework.zip",
+  "4.6.5": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.6.5/AppsFlyerTracker.framework.zip",
+  "4.7.0": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.0/AppsFlyerTracker.framework.zip",
+  "4.7.2": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.2/AppsFlyerTracker.framework.zip",
+  "4.7.3": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.3/AppsFlyerTracker.framework.zip",
+  "4.7.6": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.6/AppsFlyerTracker.framework.zip",
+  "4.7.7": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.7/AppsFlyerTracker.framework.zip",
+  "4.7.8": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.8/AppsFlyerTracker.framework.zip",
+  "4.7.9": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.9/AppsFlyerTracker.framework.zip",
+  "4.7.11": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.7.11/AppsFlyerTracker.framework.zip",
+  "4.8.0": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.8.0/AppsFlyerTracker.framework.zip",
+  "4.8.1": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.8.1/AppsFlyerTracker.framework.zip",
+  "4.8.2": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.8.2/AppsFlyerTracker.framework.zip",
+  "4.8.3": "https://github.com/AppsFlyerSDK/AppsFlyerFramework/releases/download/4.8.3/AppsFlyerTracker.framework.zip"
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ import AppsFlyerLib
 
 Just add the following into your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile):
 ```
-binary "https://raw.githubusercontent.com/AppsFlyerSDK/AppsFlyerFramework/master/Carthage.json"
+binary "https://raw.githubusercontent.com/AppsFlyerSDK/AppsFlyerFramework/master/AppsFlyerTracker.json"
 ```
 
 Then run
@@ -48,6 +48,11 @@ Then run
 ```zsh
 $ carthage bootstrap
 ```
+
+**Note :**
+Old URI referencing `Carthage.json` is deprecated. If you use it please update your Cartfife to the new one to ease dependecy management.
+
+
 
 Changelog
 ------------


### PR DESCRIPTION
To avoid naming confusion when using multiple framework binaries and allow the proper use of `update` command.
For binary frameworks distribution over Carthage, File referencing binaries should not be named **Carthage.json**.

**Note:** I didn't remove old Carthage.json in this commit and marked it as deprecated in the README file to let time to actual users to update their Cartfile.

**As an example**:
If a developer use your binary framework and another one and both don't respect naming by providing a URI to a **Carthage.json** file, the developer will not be able to update only one of them, as Carthage uses the file name as reference.

Here is the command to make an update with your current naming:
`carthage update Carthage` and this will update **both of them**.

With this Pull request, developer will be able to make `carthage update AppsFlyerTracker` to update **only this framework**.