### PR TITLE
Fix link to SDK + add link to release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![Version](https://img.shields.io/cocoapods/v/AppsFlyerFramework.svg?style=flat)](http://cocoapods.org/pods/AppsFlyerFramework)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
-In order to download and/or get instruction on how to integrate AppsFlyer iOS SDK please visit the following page - [iOS SDK](https://support.appsflyer.com/hc/en-us/sections/201691546-iOS-SDK)
+In order to download and/or get instruction on how to integrate AppsFlyer iOS SDK please visit the following page - [iOS SDK](https://support.appsflyer.com/hc/en-us/articles/207032066-AppsFlyer-SDK-Integration-iOS).
+
+Release Notes you can find [here](https://support.appsflyer.com/hc/en-us/articles/115001224823#ios-sdk-v6-release-notes).
 
 ---
 


### PR DESCRIPTION
The release notes are hard to find, so I think it makes sense to add a link in the README.